### PR TITLE
日付もちゃんと増やす

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.datapack/

--- a/data/insomnia/functions/day/add_1.mcfunction
+++ b/data/insomnia/functions/day/add_1.mcfunction
@@ -1,0 +1,4 @@
+# dec_day が 1 以上なら、 1日分計上する
+execute if score dec_day insomnia matches 1.. run time add 24000
+execute if score dec_day insomnia matches 1.. run scoreboard players remove dec_day insomnia 1
+execute if score dec_day insomnia matches 1.. run function insomnia:day/add_1

--- a/data/insomnia/functions/day/add_10.mcfunction
+++ b/data/insomnia/functions/day/add_10.mcfunction
@@ -1,0 +1,4 @@
+# dec_day が 10 以上なら、 10日分計上する
+execute if score dec_day insomnia matches 10.. run time add 240000
+execute if score dec_day insomnia matches 10.. run scoreboard players remove dec_day insomnia 10
+execute if score dec_day insomnia matches 10.. run function insomnia:day/add_10

--- a/data/insomnia/functions/day/add_100.mcfunction
+++ b/data/insomnia/functions/day/add_100.mcfunction
@@ -1,0 +1,4 @@
+# dec_day が 100 以上なら、 100日分計上する
+execute if score dec_day insomnia matches 100.. run time add 2400000
+execute if score dec_day insomnia matches 100.. run scoreboard players remove dec_day insomnia 100
+execute if score dec_day insomnia matches 100.. run function insomnia:day/add_100

--- a/data/insomnia/functions/day/add_1000.mcfunction
+++ b/data/insomnia/functions/day/add_1000.mcfunction
@@ -1,0 +1,4 @@
+# dec_day が 1000 以上なら、 1000日分計上する
+execute if score dec_day insomnia matches 1000.. run time add 24000000
+execute if score dec_day insomnia matches 1000.. run scoreboard players remove dec_day insomnia 1000
+execute if score dec_day insomnia matches 1000.. run function insomnia:day/add_1000

--- a/data/insomnia/functions/day/day_ticker.mcfunction
+++ b/data/insomnia/functions/day/day_ticker.mcfunction
@@ -1,0 +1,21 @@
+# 日付計算が必要になったら呼ばれるfunction
+
+# 日付を1日計上する
+scoreboard players add true_day insomnia 1
+
+# デクリメント用の日付を true_day にあわせる
+execute store result score dec_day insomnia run scoreboard players get true_day insomnia
+
+# 日付をとりあえず初期化する
+time set 0
+
+# 1000日単位のtime adder を呼び出す
+function insomnia:day/add_1000
+# 100日単位のtime adder を呼び出す
+function insomnia:day/add_100
+# 10日単位のtime adder を呼び出す
+function insomnia:day/add_10
+# 1日単位のtime adder を呼び出す
+function insomnia:day/add_1
+
+

--- a/data/insomnia/functions/load.mcfunction
+++ b/data/insomnia/functions/load.mcfunction
@@ -1,0 +1,3 @@
+scoreboard objectives add insomnia dummy
+# insomnia scoreboard に true_day がなければ、初期化する
+execute unless score true_day insomnia matches 0.. run scoreboard players set true_day insomnia 0

--- a/data/insomnia/functions/main.mcfunction
+++ b/data/insomnia/functions/main.mcfunction
@@ -2,6 +2,12 @@
 # 雷雨のとき誰か一人が 10tick 寝てたら、天気を晴れにする
 execute if predicate insomnia:is_thundering if entity @a[nbt={SleepTimer:30s}] run function insomnia:in_thundering
 
+## 日付対応 ##
+# 自然と日が明けたときに、 scoreboard の true_day を更新する
+execute store result score game_day insomnia run time query day
+execute if score true_day insomnia < game_day insomnia run execute store result score true_day insomnia run scoreboard players get game_day insomnia
+
 ## 夜間対応 ##
 # 12541〜23458 の間（就寝可能時間帯）なら、夜間対応を行なう（predicates/in_the_night.json参照）
 execute if predicate insomnia:in_the_night if entity @a[nbt={SleepTimer:60s}] run function insomnia:sleeper
+

--- a/data/insomnia/functions/sleeper.mcfunction
+++ b/data/insomnia/functions/sleeper.mcfunction
@@ -7,4 +7,4 @@ execute as @a[nbt={SleepTimer:60s}] run tellraw @a {"text": "", "extra": ["お�
 execute if predicate insomnia:is_raining unless predicate insomnia:is_thundering run weather rain 1
 
 # 朝にする
-time set 0
+function insomnia:day/day_ticker


### PR DESCRIPTION
`time add ****` を再帰的に呼ぶことで対応してる。

1日分の`24000`だけで対応すると1000日超えのときとか、負荷が高すぎるので、
1日毎、10日毎、100日毎、1000日毎に一括で増えるようにしている。